### PR TITLE
fix: index issue when loop is enabled

### DIFF
--- a/packages/lib/src/components/Stories.ts
+++ b/packages/lib/src/components/Stories.ts
@@ -87,7 +87,7 @@ export default defineComponent({
       if (this.index > 0)
         this.index--;
       else if (this.loop)
-        this.index = this.stories.length;
+        this.index = this.stories.length - 1;
     },
     togglePause() {
       this.paused = !this.paused


### PR DESCRIPTION
Fixed index error when trying to jump to the last story from the first when the loop is activated